### PR TITLE
Add implementation to wrap ASP binaries.

### DIFF
--- a/demtools/asp/__init__.py
+++ b/demtools/asp/__init__.py
@@ -1,0 +1,7 @@
+from .stereo import Stereo
+from .stereo_sgm import StereoSGM
+
+__all__ = [
+    'Stereo',
+    'StereoSGM',
+]

--- a/demtools/asp/stereo.py
+++ b/demtools/asp/stereo.py
@@ -35,6 +35,8 @@ class Stereo(Process):
     def algorithm(self, value):
         if value in self.ALGORITHMS.keys():
             self._algorithm = self.ALGORITHMS[value]
+        elif int(value) in self.ALGORITHMS.values():
+            self._algorithm = int(value)
         else:
             raise AttributeError("Invalid value given for algorithm.")
 

--- a/demtools/asp/stereo.py
+++ b/demtools/asp/stereo.py
@@ -53,6 +53,10 @@ class Stereo(Process):
         else:
             self._map_projected = None
 
+    @staticmethod
+    def sgm_algorithm(algorithm_value):
+        return int(algorithm_value) in [1, 2]
+
     def in_option_blacklist(self, option, blacklist):
         match = self.RUN_OPTIONS_FILTER.match(option)
         return match[1] in blacklist if match is not None else False
@@ -80,4 +84,3 @@ class Stereo(Process):
         self.run_options = self.stereo_run_options() + self.run_options
 
         return super().run_call(verbose)
-

--- a/demtools/asp/stereo.py
+++ b/demtools/asp/stereo.py
@@ -55,7 +55,7 @@ class Stereo(Process):
 
     def in_option_blacklist(self, option, blacklist):
         match = self.RUN_OPTIONS_FILTER.match(option)
-        return match[1] in blacklist
+        return match[1] in blacklist if match is not None else False
 
     def filter_run_options(self, blacklist):
         self.run_options = [
@@ -80,3 +80,4 @@ class Stereo(Process):
         self.run_options = self.stereo_run_options() + self.run_options
 
         return super().run_call(verbose)
+

--- a/demtools/asp/stereo.py
+++ b/demtools/asp/stereo.py
@@ -1,0 +1,74 @@
+import re
+
+from demtools import Process
+
+
+class Stereo(Process):
+    ALGORITHMS = {
+        'Local': 0,     # Local Search Window
+        'SGM': 1,       # Semi-Global Matching
+        'SSGM': 2,      # Smooth Semi-Global Matching
+        'MGM': 3,       # More Global Matching
+    }
+
+    NO_DATA_VALUE = "--nodata-value -32768"
+    MAP_PROJECT_OPTIONS = ['-t dgmaprpc', '--alignment-method None']
+    STEREO_ALGORITHM_OPTION = "--stereo-algorithm {0}"
+
+    RUN_OPTIONS_FILTER = re.compile(r"(?:-{1,2})([\w-]+)\s+(-?[\w\s]*)")
+    RUN_OPTION_BLACKLIST = [
+        't', 'alignment-method', 'stereo-algorithm'
+    ]
+
+    RUN_COMMAND = 'stereo'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.algorithm = kwargs.get('algorithm', 'Local')
+        self.map_projected = kwargs.get('map_projected', False)
+
+    @property
+    def algorithm(self):
+        return self._algorithm
+
+    @algorithm.setter
+    def algorithm(self, value):
+        if value in self.ALGORITHMS.keys():
+            self._algorithm = self.ALGORITHMS[value]
+        else:
+            raise AttributeError("Invalid value given for algorithm.")
+
+    @property
+    def map_projected(self):
+        return self._map_projected
+
+    @map_projected.setter
+    def map_projected(self, value):
+        self._map_projected = value
+
+    def in_option_blacklist(self, option):
+        match = self.RUN_OPTIONS_FILTER.match(option)
+        return match[1] in self.RUN_OPTION_BLACKLIST
+
+    def filter_run_options(self):
+        self.run_options = [
+            option for option in self._run_options
+            if not self.in_option_blacklist(option)
+        ]
+
+    def stereo_run_options(self):
+        run_options = [
+            self.STEREO_ALGORITHM_OPTION.format(self.algorithm),
+            self.NO_DATA_VALUE,
+        ]
+
+        if self.map_projected:
+            run_options.extend(self.MAP_PROJECT_OPTIONS)
+
+        return run_options
+
+    def run_call(self, verbose=False):
+        self.filter_run_options()
+        self.run_options = self.stereo_run_options() + self.run_options
+
+        return super().run_call(verbose)

--- a/demtools/asp/stereo_sgm.py
+++ b/demtools/asp/stereo_sgm.py
@@ -3,8 +3,31 @@ from demtools.asp import Stereo
 
 
 class StereoSGM(Stereo):
-    RUN_COMMAND = 'parallel_stereo'
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.algorithm = kwargs.get('algorithm', 'SGM')
+        self._parallel = kwargs.get('parallel', False)
+        self.processes = kwargs.get('processes', None)
+
+    @property
+    def processes(self):
+        return self._processes
+
+    @processes.setter
+    def processes(self, value):
+        if self._parallel and value is None:
+            raise AttributeError("Parallel processing requested, but no "
+                                 "number of processes given in options")
+        else:
+            self._processes = value
+
+    def parallel_run_options(self):
+        return [f'--processes {self.processes}']
+
+    def run_call(self, verbose=False):
+        if self._parallel:
+            self.run_command = f'parallel_{self.run_command}'
+
+            self.run_options = self.parallel_run_options() + self.run_options
+
+        return super().run_call(verbose=verbose)

--- a/demtools/asp/stereo_sgm.py
+++ b/demtools/asp/stereo_sgm.py
@@ -1,0 +1,10 @@
+
+from demtools.asp import Stereo
+
+
+class StereoSGM(Stereo):
+    RUN_COMMAND = 'parallel_stereo'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.algorithm = kwargs.get('algorithm', 'SGM')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-from pathlib import PurePath
+import os
+from pathlib import Path, PurePath
 
 import pytest
 
@@ -11,3 +12,10 @@ def fixture_path():
 @pytest.fixture(scope='module')
 def tmp_input_path(tmpdir_factory):
     return tmpdir_factory.mktemp('test_input_path')
+
+
+@pytest.fixture()
+def mock_run_command(request, monkeypatch, tmpdir_factory):
+    bin_dir = tmpdir_factory.mktemp('bin')
+    Path(bin_dir.join(request.param)).touch(mode=0o777)
+    monkeypatch.setenv("PATH", str(bin_dir), prepend=os.pathsep)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ def tmp_input_path(tmpdir_factory):
 @pytest.fixture()
 def mock_run_command(request, monkeypatch, tmpdir_factory):
     bin_dir = tmpdir_factory.mktemp('bin')
-    Path(bin_dir.join(request.param)).touch(mode=0o777)
-    # TODO - Needed for StereoSGM test case.
-    # Can't quite figure out, why mark.parametrize is not working
-    # This should be improved in future revisions.
-    Path(bin_dir.join(f'parallel_{request.param}')).touch(mode=0o777)
+    commands = request.param
+    if type(commands) is not list:
+        commands = [commands]
+    for command in commands:
+        Path(bin_dir.join(command)).touch(mode=0o777)
     monkeypatch.setenv("PATH", str(bin_dir), prepend=os.pathsep)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,4 +18,8 @@ def tmp_input_path(tmpdir_factory):
 def mock_run_command(request, monkeypatch, tmpdir_factory):
     bin_dir = tmpdir_factory.mktemp('bin')
     Path(bin_dir.join(request.param)).touch(mode=0o777)
+    # TODO - Needed for StereoSGM test case.
+    # Can't quite figure out, why mark.parametrize is not working
+    # This should be improved in future revisions.
+    Path(bin_dir.join(f'parallel_{request.param}')).touch(mode=0o777)
     monkeypatch.setenv("PATH", str(bin_dir), prepend=os.pathsep)

--- a/tests/demtools/asp/test_stereo.py
+++ b/tests/demtools/asp/test_stereo.py
@@ -68,3 +68,8 @@ class TestStereo(object):
         assert '--stereo-algorithm 3' not in run_call
         assert '--threads 6' in run_call
         assert '--processes 4' in run_call
+
+    def test_keep_unknown_run_options(self):
+        subject = Stereo(run_options=['path/to/file'])
+        run_call = subject.run_call()
+        assert 'path/to/file' in run_call

--- a/tests/demtools/asp/test_stereo.py
+++ b/tests/demtools/asp/test_stereo.py
@@ -11,10 +11,19 @@ class TestStereo(object):
     def test_run(self):
         assert Stereo().run_command == 'stereo'
 
-    def test_algorithm_option(self):
+    def test_algorithm_option_with_keys(self):
         for algorithm in ['Local', 'SGM', 'SSGM', 'MGM']:
             assert Stereo(algorithm=algorithm).algorithm == \
                    Stereo.ALGORITHMS[algorithm]
+
+    def test_algorithm_option_with_values(self):
+        for algorithm_value in [0, 1, 2, 3]:
+            assert Stereo(algorithm=algorithm_value).algorithm == \
+                   algorithm_value
+
+        for algorithm_value in ['0', '1', '2', '3']:
+            assert Stereo(algorithm=algorithm_value).algorithm == \
+                   int(algorithm_value)
 
     def test_map_projected(self):
         subject = Stereo(map_projected=True)

--- a/tests/demtools/asp/test_stereo.py
+++ b/tests/demtools/asp/test_stereo.py
@@ -26,7 +26,7 @@ class TestStereo(object):
                    int(algorithm_value)
 
     def test_map_projected(self):
-        subject = Stereo(map_projected=True)
+        subject = Stereo(map_projected='dgmaprpc')
         run_call = subject.run_call()
         assert '-t dgmaprpc' in run_call
         assert '--alignment-method None' in run_call
@@ -40,7 +40,7 @@ class TestStereo(object):
 
     def test_map_projected_filter_options(self):
         options = ['-t foo', '--alignment-method align']
-        subject = Stereo(map_projected=True, run_options=options)
+        subject = Stereo(map_projected='dgmaprpc', run_options=options)
         run_call = subject.run_call()
         assert '-t dgmaprpc' in run_call
         assert '--alignment-method None' in run_call
@@ -48,7 +48,15 @@ class TestStereo(object):
         assert '--alignment-method align' not in run_call
         assert len(run_call) == 5
 
-    def test_filter_run_options(self):
+    def test_keep_session_type_options(self):
+        options = ['-t pinhole', '--alignment-method affine']
+        subject = Stereo(run_options=options)
+        run_call = subject.run_call()
+        assert '-t pinhole' in run_call
+        assert '--alignment-method affine' in run_call
+        assert len(run_call) == 5
+
+    def test_filter_algorithm_run_options(self):
         subject = Stereo(run_options=['--stereo-algorithm 3'])
         run_call = subject.run_call()
         assert '--stereo-algorithm 3' not in run_call

--- a/tests/demtools/asp/test_stereo.py
+++ b/tests/demtools/asp/test_stereo.py
@@ -1,0 +1,53 @@
+import pytest
+
+from demtools.asp import Stereo
+
+
+@pytest.mark.parametrize(
+    'mock_run_command', [Stereo.RUN_COMMAND], indirect=True
+)
+@pytest.mark.usefixtures('mock_run_command')
+class TestStereo(object):
+    def test_run(self):
+        assert Stereo().run_command == 'stereo'
+
+    def test_algorithm_option(self):
+        for algorithm in ['Local', 'SGM', 'SSGM', 'MGM']:
+            assert Stereo(algorithm=algorithm).algorithm == \
+                   Stereo.ALGORITHMS[algorithm]
+
+    def test_map_projected(self):
+        subject = Stereo(map_projected=True)
+        run_call = subject.run_call()
+        assert '-t dgmaprpc' in run_call
+        assert '--alignment-method None' in run_call
+        assert len(run_call) == 5
+
+    def test_default_run_options(self):
+        run_call = Stereo().run_call()
+        assert '--stereo-algorithm 0' in run_call
+        assert '--nodata-value -32768' in run_call
+        assert len(run_call) == 3
+
+    def test_map_projected_filter_options(self):
+        options = ['-t foo', '--alignment-method align']
+        subject = Stereo(map_projected=True, run_options=options)
+        run_call = subject.run_call()
+        assert '-t dgmaprpc' in run_call
+        assert '--alignment-method None' in run_call
+        assert '-t foo' not in run_call
+        assert '--alignment-method align' not in run_call
+        assert len(run_call) == 5
+
+    def test_filter_run_options(self):
+        subject = Stereo(run_options=['--stereo-algorithm 3'])
+        run_call = subject.run_call()
+        assert '--stereo-algorithm 3' not in run_call
+        assert '--stereo-algorithm 0' in run_call     # Default Stereo algorithm
+
+    def test_keep_custom_run_options(self):
+        subject = Stereo(run_options=['--threads 6', '--processes 4'])
+        run_call = subject.run_call()
+        assert '--stereo-algorithm 3' not in run_call
+        assert '--threads 6' in run_call
+        assert '--processes 4' in run_call

--- a/tests/demtools/asp/test_stereo.py
+++ b/tests/demtools/asp/test_stereo.py
@@ -74,3 +74,8 @@ class TestStereo(object):
         subject = Stereo(run_options=['path/to/file'])
         run_call = subject.run_call()
         assert 'path/to/file' in run_call
+
+    def test_sgm_algorithm(self):
+        assert Stereo.sgm_algorithm('1')
+        assert Stereo.sgm_algorithm(1)
+        assert not Stereo.sgm_algorithm(3)

--- a/tests/demtools/asp/test_stereo.py
+++ b/tests/demtools/asp/test_stereo.py
@@ -60,7 +60,8 @@ class TestStereo(object):
         subject = Stereo(run_options=['--stereo-algorithm 3'])
         run_call = subject.run_call()
         assert '--stereo-algorithm 3' not in run_call
-        assert '--stereo-algorithm 0' in run_call     # Default Stereo algorithm
+        # Default Stereo algorithm
+        assert '--stereo-algorithm 0' in run_call
 
     def test_keep_custom_run_options(self):
         subject = Stereo(run_options=['--threads 6', '--processes 4'])

--- a/tests/demtools/asp/test_stereo_sgm.py
+++ b/tests/demtools/asp/test_stereo_sgm.py
@@ -1,0 +1,15 @@
+import pytest
+
+from demtools.asp import StereoSGM
+
+
+@pytest.mark.parametrize(
+    'mock_run_command', [StereoSGM.RUN_COMMAND], indirect=True
+)
+@pytest.mark.usefixtures('mock_run_command')
+class TestStereoSGM(object):
+    def test_run(self):
+        assert StereoSGM().run_command == 'parallel_stereo'
+
+    def test_algorithm_default(self):
+        assert StereoSGM().algorithm == 1

--- a/tests/demtools/asp/test_stereo_sgm.py
+++ b/tests/demtools/asp/test_stereo_sgm.py
@@ -9,7 +9,18 @@ from demtools.asp import StereoSGM
 @pytest.mark.usefixtures('mock_run_command')
 class TestStereoSGM(object):
     def test_run(self):
-        assert StereoSGM().run_command == 'parallel_stereo'
+        stereo_run_call = StereoSGM().run_call()
+        assert stereo_run_call[0] == 'stereo'
+        assert '--processes' not in stereo_run_call
 
     def test_algorithm_default(self):
         assert StereoSGM().algorithm == 1
+
+    def test_run_in_parallel(self):
+        stereo_run_call = StereoSGM(parallel=True, processes=4).run_call()
+        assert stereo_run_call[0] == 'parallel_stereo'
+        assert '--processes 4' in stereo_run_call
+
+    def test_run_in_parallel_needs_processes(self):
+        with pytest.raises(AttributeError, match=r'no number of processes'):
+            assert StereoSGM(parallel=True)

--- a/tests/demtools/asp/test_stereo_sgm.py
+++ b/tests/demtools/asp/test_stereo_sgm.py
@@ -4,7 +4,9 @@ from demtools.asp import StereoSGM
 
 
 @pytest.mark.parametrize(
-    'mock_run_command', [StereoSGM.RUN_COMMAND], indirect=True
+    'mock_run_command',
+    [[StereoSGM.RUN_COMMAND, 'parallel_stereo']],
+    indirect=True
 )
 @pytest.mark.usefixtures('mock_run_command')
 class TestStereoSGM(object):


### PR DESCRIPTION
Add wrappers for ASP stereo commands. The base Stereo class wraps the
'stereo' command itself, while the subclass StereoSGM is changed to use
'parallel_stereo'.