### PR TITLE
Add InputPath validator for argparse.

### DIFF
--- a/demtools/scripts/__init__.py
+++ b/demtools/scripts/__init__.py
@@ -1,0 +1,5 @@
+from .input_path import InputPath
+
+__all__ = [
+    'InputPath',
+]

--- a/demtools/scripts/input_path.py
+++ b/demtools/scripts/input_path.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+
+
+class InputPath(object):
+    """
+    Class to use with argparse 'type' option.
+    When given a directory or file paths, it first checks for existence and
+    then whether the paths is accessible for reading.
+
+    Example:
+        argument_parser = argparse.ArgumentParser()
+        argument_parser.add_argument(
+            'file',
+            type=InputPath(),
+        )
+    """
+    @staticmethod
+    def check_exists(input_path):
+        if not os.path.exists(input_path):
+            raise argparse.ArgumentTypeError(
+                f'Unable to find input path: {input_path}'
+            )
+
+    @staticmethod
+    def check_readable(input_path):
+        if not os.access(input_path, os.R_OK):
+            raise argparse.ArgumentTypeError(
+                f'Given input path is not readable.'
+                f'  Path: {input_path}'
+            )
+
+    def __call__(self, input_path):
+        self.check_exists(input_path)
+        self.check_readable(input_path)
+        return input_path

--- a/tests/demtools/test_input_path.py
+++ b/tests/demtools/test_input_path.py
@@ -1,0 +1,58 @@
+import argparse
+from pathlib import Path
+
+import pytest
+
+from demtools.scripts import InputPath
+
+
+@pytest.fixture(scope='module')
+def tmp_test_file(tmp_input_path):
+    file = Path(tmp_input_path.join('test_input_file.txt'))
+    print(str(file))
+    file.touch(mode=0o644, exist_ok=True)
+    return file
+
+
+@pytest.fixture(scope='module')
+def tmp_test_path(tmp_test_file):
+    return tmp_test_file.parent
+
+
+@pytest.fixture(scope='module')
+def subject():
+    return InputPath()
+
+
+class TestInputPaths(object):
+    def test_path_exists(self, subject, tmp_test_path):
+        assert subject(tmp_test_path) == tmp_test_path
+
+    def test_path_does_not_exists(self, subject):
+        with pytest.raises(argparse.ArgumentTypeError, match=r'Unable to find'):
+            subject('/tmp/does_not_exist')
+
+    def test_path_not_readable(self, subject, tmp_test_path):
+        tmp_test_path.chmod(000)
+        with pytest.raises(
+                argparse.ArgumentTypeError, match=r'not readable'
+        ):
+            subject(tmp_test_path)
+        tmp_test_path.chmod(0o755)
+
+    def test_file_exists(self, subject, tmp_test_file):
+        assert subject(tmp_test_file) == tmp_test_file
+
+    def test_file_does_not_exists(self, subject):
+        with pytest.raises(
+                argparse.ArgumentTypeError, match=r'Unable to find'
+        ):
+            subject('/tmp/does_not_exist.txt')
+
+    def test_file_not_readable(self, subject, tmp_test_file):
+        tmp_test_file.chmod(000)
+        with pytest.raises(
+                argparse.ArgumentTypeError, match=r'not readable'
+        ):
+            subject(tmp_test_file)
+        tmp_test_file.chmod(0o755)


### PR DESCRIPTION
Add a validator that can be used as a type for `argparse.add_argument`.
See class description for usage.